### PR TITLE
Don't error out when a lighter is not defined

### DIFF
--- a/diminish.el
+++ b/diminish.el
@@ -177,14 +177,14 @@ to TO-WHAT if it's > 1 char long & doesn't already begin with a space."
                       "To what mode-line display: "
                       nil nil nil 'diminish-history-names)))
   (let ((minor (assq mode minor-mode-alist)))
-    (or minor (error "%S is not currently registered as a minor mode" mode))
-    (callf or to-what "")
-    (when (> (length to-what) 1)
-      (or (= (string-to-char to-what) ?\ )
-          (callf2 concat " " to-what)))
-    (or (assq mode diminished-mode-alist)
-        (push (copy-sequence minor) diminished-mode-alist))
-    (setcdr minor (list to-what))))
+    (when minor
+        (progn (callf or to-what "")
+               (when (> (length to-what) 1)
+                 (or (= (string-to-char to-what) ?\ )
+                     (callf2 concat " " to-what)))
+               (or (assq mode diminished-mode-alist)
+                   (push (copy-sequence minor) diminished-mode-alist))
+               (setcdr minor (list to-what))))))
 
 ;; But an image comes to me, vivid in its unreality, of a loon alone on his
 ;; forest lake, shrieking his soul out into a canopy of stars.  Alone this


### PR DESCRIPTION
I would like to propose a patch related to https://github.com/syl20bnr/spacemacs/issues/4172. So if a package decides to remove the lighter of a package diminish.el will throw an error. This patch removes the error signal as it probably causes more harm than good.
