### PR TITLE
Revert "Replace deprecated 'cl package by 'cl-lib"

### DIFF
--- a/diminish.el
+++ b/diminish.el
@@ -105,7 +105,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
+(eval-when-compile (require 'cl))
 
 (defvar diminish-must-not-copy-minor-mode-alist nil
   "Non-nil means loading diminish.el won't (copy-alist minor-mode-alist).


### PR DESCRIPTION
Reverts myrjola/diminish.el#7

After it was merged, users reported breakage https://github.com/myrjola/diminish.el/issues/8.