### PR TITLE
Replace cl with cl-lib (Fix #8)

### DIFF
--- a/diminish.el
+++ b/diminish.el
@@ -4,9 +4,10 @@
 
 ;; Author: Will Mengarini <seldon@eskimo.com>
 ;; Maintainer: Martin Yrjölä <martin.yrjola@gmail.com>
-;; URL: <https://github.com/myrjola/diminish.el>
+;; URL: https://github.com/myrjola/diminish.el
 ;; Created: Th 19 Feb 98
 ;; Version: 0.45
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: extensions, diminish, minor, codeprose
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -105,7 +106,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defvar diminish-must-not-copy-minor-mode-alist nil
   "Non-nil means loading diminish.el won't (copy-alist minor-mode-alist).
@@ -116,7 +117,7 @@ try to diminish abbrev-mode under GNU Emacs 19.34, you'll get the error
 message \"Attempt to modify read-only object\".")
 
 (or diminish-must-not-copy-minor-mode-alist
-    (callf copy-alist minor-mode-alist))
+    (cl-callf copy-alist minor-mode-alist))
 
 (defvar diminished-mode-alist nil
   "The original `minor-mode-alist' value of all (diminish)ed modes.")
@@ -177,11 +178,11 @@ to TO-WHAT if it's > 1 char long & doesn't already begin with a space."
                       nil nil nil 'diminish-history-names)))
   (let ((minor (assq mode minor-mode-alist)))
     (when minor
-        (progn (callf or to-what "")
+        (progn (cl-callf or to-what "")
                (when (and (stringp to-what)
                           (> (length to-what) 1))
                  (or (= (string-to-char to-what) ?\ )
-                     (callf2 concat " " to-what)))
+                     (cl-callf2 concat " " to-what)))
                (or (assq mode diminished-mode-alist)
                    (push (copy-sequence minor) diminished-mode-alist))
                (setcdr minor (list to-what))))))
@@ -223,7 +224,7 @@ the arg must be quoted as a symbol, as in (diminish-undo 'diminished-modes)."
       (let ((diminished-modes diminished-mode-alist))
         (while diminished-modes
           (diminish-undo (caar diminished-modes))
-          (callf cdr diminished-modes)))
+          (cl-callf cdr diminished-modes)))
     (let ((minor      (assq mode      minor-mode-alist))
           (diminished (assq mode diminished-mode-alist)))
       (or minor
@@ -260,14 +261,14 @@ what diminished modes would be on the mode-line if they were still minor."
           (when (symbolp minor-name)
             ;; This minor mode uses symbol indirection in the cdr
             (let ((symbols-seen (list minor-name)))
-              (while (and (symbolp (callf symbol-value minor-name))
+              (while (and (symbolp (cl-callf symbol-value minor-name))
                           (not (memq minor-name symbols-seen)))
                 (push minor-name symbols-seen))))
           (push minor-name message)))
-      (callf cdr minor-modes))
+      (cl-callf cdr minor-modes))
     (setq message (mapconcat 'identity (nreverse message) ""))
     (when (= (string-to-char message) ?\ )
-      (callf substring message 1))
+      (cl-callf substring message 1))
     (message "%s" message)))
 
 ;; A human mind is a Black Forest of diminished modes.  Some are dangerous;


### PR DESCRIPTION
1. Reuquire Emacs 24.3. According to package-lint:
```
You should depend on (emacs "24.3") or the cl-lib package if you need `cl-lib'.
```

2. `callf` and `callf2` replaced by `cl-callf` and `cl-callf2` accordingly.

3. Fixed package URL. package-lint again:
```
Package URLs should be a single HTTPS or HTTP URL.
```