### PR TITLE
Add more usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,21 @@ Quick start
 
 ```emacs-lisp
 (require 'diminish)
-;; Hide jiggle-mode lighter from mode line
-(diminish 'jiggle-mode)
-;; Replace abbrev-mode lighter with "Abv"
-(diminish 'abbrev-mode "Abv")
+
+(diminish 'rainbow-mode)                                       ; Hide lighter from mode-line
+(diminish 'rainbow-mode " Rbow")                               ; Replace rainbow-mode lighter with " Rbow"
+(diminish 'rainbow-mode 'rainbow-mode-lighter)                 ; Use raingow-mode-lighter variable value
+(diminish 'rainbow-mode '(" " "R-" "bow"))                     ; Replace rainbow-mode lighter with " R-bow"
+(diminish 'rainbow-mode '((" " "R") "/" "bow"))                ; Replace rainbow-mode lighter with " R/bow"
+(diminish 'rainbow-mode '(:eval (format " Rbow/%s" (+ 2 3))))  ; Replace rainbow-mode lighter with " Rbow/5"
+(diminish 'rainbow-mode                                        ; Replace rainbow-mode lighter with greened " Rbow"
+  '(:propertize " Rbow" face '(:foreground "green")))
+(diminish 'rainbow-mode                                        ; If rainbow-mode-mode-linep is non-nil " Rbow/t"
+  '(rainbow-mode-mode-linep " Rbow/t" " Rbow/nil"))
+(diminish 'rainbow-mode '(3 " Rbow" "/" "s"))                  ; Replace rainbow-mode lighter with " Rb"
 ```
+
+Ref: [Emacs manual - The Data Structure of the Mode Line](https://www.gnu.org/software/emacs/manual/html_node/elisp/Mode-Line-Data.html).
 
 John Wiegley's
 [use-package](https://github.com/jwiegley/use-package#diminishing-and-delighting-minor-modes)


### PR DESCRIPTION
Hi!
diminish is now accept any mode-line construct via #4.
I add more usage to README.

Note:
Last usage; `(diminish 'rainbow-mode '(3 " Rbow" "/" "s"))` doesn't
work in my environment...
Could you check the usage? or (Emacs's) bugs?