### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/diminish.el
+++ b/diminish.el
@@ -157,7 +157,7 @@ Interactively, enter (with completion) the name of any minor mode, followed
 on the next line by what you want it diminished to (default empty string).
 The response to neither prompt should be quoted.  However, in Lisp code,
 both args must be quoted, the first as a symbol, the second as a string,
-as in (diminish 'jiggle-mode \" Jgl\").
+as in (diminish \\='jiggle-mode \" Jgl\").
 
 The mode-line displays of minor modes usually begin with a space, so
 the modes' names appear as separate words on the mode line.  However, if
@@ -210,7 +210,7 @@ Interactively, enter (with completion) the name of any diminished mode (a
 mode that was formerly a minor mode on which you invoked \\[diminish]).
 To restore all diminished modes to minor status, answer `diminished-modes'.
 The response to the prompt shouldn't be quoted.  However, in Lisp code,
-the arg must be quoted as a symbol, as in (diminish-undo 'diminished-modes)."
+the arg must be quoted as a symbol, as in (diminish-undo \\='diminished-modes)."
   (interactive
    (list (read (completing-read
                 "Restore what diminished mode: "


### PR DESCRIPTION
```
 ■  Warning (comp): diminish.el:155:2: Warning: docstring has wrong
usage of unescaped single quotes (use \= or different quoting)
 ■  Warning (comp): diminish.el:207:2: Warning: docstring has wrong
usage of unescaped single quotes (use \= or different quoting)
```

To reproduce, have emacs build with native compilation and notice the compilation logs. You can then open this file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.